### PR TITLE
Fix returning array when expecting string

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -116,7 +116,7 @@ class Casher
   end
 
   def fetched_archive
-    [ File.expand_path('fetch.tbz', @casher_dir), File.expand_path('fetch.tgz', @casher_dir) ].select do |f|
+    [ File.expand_path('fetch.tbz', @casher_dir), File.expand_path('fetch.tgz', @casher_dir) ].find do |f|
       File.exist? f
     end
   end


### PR DESCRIPTION
```
/home/travis/.casher/bin/casher:106:in `tar': undefined method `end_with?' for []:Array (NoMethodError)
	from /home/travis/.casher/bin/casher:70:in `block in add'
	from /home/travis/.casher/bin/casher:65:in `each'
	from /home/travis/.casher/bin/casher:65:in `add'
	from /home/travis/.casher/bin/casher:35:in `block in run'
	from /home/travis/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/timeout.rb:69:in `timeout'
	from /home/travis/.casher/bin/casher:35:in `run'
	from /home/travis/.casher/bin/casher:125:in `<main>'
```