### PR TITLE
Possible bugs when paths contain spaces

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -98,6 +98,7 @@ class Casher
 
     if md5deep_available?
       File.open(@paths_file, 'a') { |f| f << expanded_paths.join("\n") << "\n" }
+      BUGGY?             ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓
       system "md5deep -r #{expanded_paths.join(' ')} | sort >> #{@checksum_file_before}"
     else
       File.open(@mtime_file, 'w') { |f| f << @mtimes.to_yaml }
@@ -135,6 +136,7 @@ class Casher
     if md5deep_available?
       paths  = File.read(@paths_file).gsub("\n", ' ')
       diff_file = File.expand_path('checksum_diff', @casher_dir)
+      BUGGY?             ↓↓↓↓↓↓↓↓
       system("md5deep -r #{paths} | sort > #{@checksum_file_after}; diff -B #{@checksum_file_before} #{@checksum_file_after} | awk '/^[<>]/ {print $NF}' | sort | uniq > #{diff_file}")
 
       result = File.size(@checksum_file_before) == 0 || File.size(diff_file) > 0


### PR DESCRIPTION
This code seems potentially buggy when the paths include spaces. No escaping/quoting seems to be performed on the paths. So when the shell tokenizes the command, e.g. `/foo/my file.txt` will be interpreted as two filepaths, `/foo/my` and `file.txt`

Again, I'm grasping at straws that have even a tiny chance of explaining https://github.com/travis-ci/travis-ci/issues/5092

This is filed as a dummy PR because this repo has its Issue Tracker disabled for some reason.