### PR TITLE
If possible, run tar as root

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -177,6 +177,9 @@ class Casher
     compression_flag = file.end_with?('.tbz') ? 'j' : 'z'
 
     cmd = "tar -P#{compression_flag}#{flag}f #{Shellwords.escape(file)} #{Shellwords.join(args)}"
+    if system "sudo -v"
+      cmd = "sudo " + cmd
+    end
     stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)
     while wait_thr.status do
       yield


### PR DESCRIPTION
This prevents a lot of permission denied problems that are very hard to fix without this (there's no build step before installing the cache). In my case, I'm trying to cache `/var/lib/docker`, so I need to preserve permissions. Tar will automatically do that if running as root.