### PR TITLE
Fix sudo detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 
 sudo: false
 
+os:
+  - linux
+  - osx
+
 rvm:
   - 1.9.3
   - 2.1.5

--- a/bin/casher
+++ b/bin/casher
@@ -177,7 +177,8 @@ class Casher
     compression_flag = file.end_with?('.tbz') ? 'j' : 'z'
 
     cmd = "tar -P#{compression_flag}#{flag}f #{Shellwords.escape(file)} #{Shellwords.join(args)}"
-    if ! system('sw_vers', %i[out err] => '/dev/null') and system "sudo -v"
+    if system "sudo -nv"
+      msg "using sudo for tar"
       cmd = "sudo " + cmd
     end
     stdin, stdout, stderr, wait_thr = Open3.popen3(cmd)

--- a/spec/casher_spec.rb
+++ b/spec/casher_spec.rb
@@ -1,5 +1,7 @@
 load File.join(File.dirname(__FILE__), '..', 'bin', 'casher')
 
+require 'tmpdir'
+
 describe Casher do
   let(:tbz_url) { 'https://example.com/afdfad/master/cache--rvm-default--gemfile-Gemfile.tbz?param1=value1&param2=value2' }
   let(:tgz_url) { 'https://example.com/afdfad/master/cache--rvm-default--gemfile-Gemfile.tgz?param1=value1&param2=value2' }
@@ -21,6 +23,28 @@ describe Casher do
     it 'falls back to the next archive' do
       expect(subject).to receive(:system).with(/curl\b.*#{tbz_url.gsub('?','\?')}/m)
       subject.run('fetch', tgz_url, tbz_url)
+    end
+  end
+
+  describe '#tar' do
+    it 'creates and extracts tar files' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir dir do
+          Dir.mkdir 'tar-input'
+          File.write('tar-input/file.txt', 'file contents')
+          out, errs = subject.tar(:c, 'archive.tbz', 'tar-input') do
+            sleep 1
+          end
+          expect(errs).to eq ('')
+          File.delete('tar-input/file.txt')
+          Dir.delete('tar-input')
+          out, errs = subject.tar(:x, 'archive.tbz', 'tar-input') do
+            sleep 1
+          end
+          expect(errs).to eq ('')
+          expect(File.read 'tar-input/file.txt').to eq('file contents')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From `man sudo`:

```
-n, --non-interactive
                 Avoid prompting the user for input of any kind.  If a password is required for the command to run, sudo will display an error message and exit.
```

The option is also available in OS X's sudo: https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man8/sudo.8.html