### PR TITLE
Remove from curl's STDERR lines starting with 'PUT'

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -203,7 +203,7 @@ class Casher
 
     if !status.success? && flag.to_s != 'x'
       msg "FAILED: #{cmd}", :red
-      puts errors, output
+      puts errors.delete_if {|l| l.start_with? 'PUT'}, output
     end
 
     [stdout, errors]


### PR DESCRIPTION
This probably contains signed URL that we want to hide from plain view.