### PR TITLE
Bash fixes for extracting absolute paths and corrected message prints

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -120,7 +120,7 @@ function add {
 
   if [[ -e ${FETCH_TAR} ]]; then
     # expand the archive, while recording directories not found in the archive
-    dir_not_found=$(tar xf ${FETCH_TAR} "$@" 2>&1 | grep 'Not found' | sed -e 's/tar: \(.*\): Not found.*$/\1/g')
+    dir_not_found=$(tar xPf ${FETCH_TAR} "$@" 2>&1 | grep 'Not found' | sed -e 's/tar: \(.*\): Not found.*$/\1/g')
     IFS=" "
     for dir in ${dir_not_found}; do
       msg "${dir} is not yet cached" red

--- a/bin/casher
+++ b/bin/casher
@@ -103,7 +103,7 @@ function fetch {
 function add {
   for path in "$@"; do
     if [[ -L ${path} ]]; then
-      msg "${path} is a symbolic link to $(readlink ${paht}); not following"
+      msg "${path} is a symbolic link to $(readlink ${path}); not following"
       continue
     fi
 

--- a/bin/casher
+++ b/bin/casher
@@ -64,7 +64,7 @@ function msg {
       ;;
   esac
 
-  echo -e "${marker}${text}${ANSI_RESET}"
+  printf "${marker}%s${ANSI_RESET}\n" "$text"
 }
 
 function run {

--- a/bin/casher
+++ b/bin/casher
@@ -90,7 +90,7 @@ function fetch {
 
     msg "fetching ${display_name}" green
 
-    curl $url -o ${FETCH_TAR} -f -s --retry 3 >fetch.log 2>fetch.err.log
+    curl $url -o ${FETCH_TAR} -f -s --retry 3 >${CASHER_DIR}/fetch.log 2>${CASHER_DIR}/fetch.err.log
     if [[ $? = 0 ]]; then
       msg "found cache" green
       return


### PR DESCRIPTION
While trying the experimental Windows integration, I found that absolute paths were not properly extracted and messages with backslashes were incorrectly unescaped.

See also: https://travis-ci.community/t/feedback-from-windows-integration-for-a-cmake-qt-c-python-perl-project/1706/1