### PR TITLE
remove sudo key since it's been deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 rvm:
   - 1.9.3
   - 2.1.5


### PR DESCRIPTION
Travis CI uses a single linux infrastructure https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration