### PR TITLE
Choose compression method basing on url

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -143,7 +143,8 @@ function push {
 
   msg "changes detected, packing new archive" green
 
-  tar -Pcjf ${PUSH_TAR} $(<${PATHS_FILE})
+  if [[ $(awk '{print tolower($0)}' <<< ${url##*.}) = "tbz" ]]; then compression_flag="j"; else compression_flag="z"; fi;
+  tar -Pc${compression_flag}f ${PUSH_TAR} $(<${PATHS_FILE})
 
   msg "uploading $(display_name $url)" green
   curl -T ${PUSH_TAR} $url -f -v >${CASHER_DIR}/push.log 2>${CASHER_DIR}/push.err.log


### PR DESCRIPTION
Travis CI fetches and pushes tgz archives with the name like
cache-windows-1803-containers-hash--compiler-gpp.tgz
but misleadingly compresses them as tbz archives.

According to https://tukaani.org/lzma/benchmarks.html
203 MB file takes
2 m 37 s to compress
32.2 s to decompress
and yields 34 % compression ratio for bzip2.

The same file takes
66.9 s to compress
3.1 s to decompress
and yields 37 % compression ratio for gzip.

The difference in compression/decompression time is huge and in
compression ration small, so gzip should be used by default.

Rubby casher uses following line
compression_flag = file.end_with?('.tbz') ? 'j' : 'z'
to determine compression method.