### PR TITLE
Allow multiple executions of `casher` without sharing files

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -32,6 +32,31 @@ PUSH_TAR=${CASHER_DIR}/push.tgz
 
 DIFF_FILE=${CASHER_DIR}/checksum_diff
 
+args=()
+
+function process_flags {
+  local name
+  for arg in $@; do
+     case $arg in
+      --name )
+        shift
+        name=$1
+        shift
+        PATHS_FILE=${CASHER_DIR}/${name}.paths
+        CHECKSUM_FILE_BEFORE=${CASHER_DIR}/${name}.md5sums_before
+        CHECKSUM_FILE_AFTER=${CASHER_DIR}/${name}.md5sums_after
+        FETCH_TAR=${CASHER_DIR}/${name}.tgz
+        PUSH_TAR=${CASHER_DIR}/${name}.tgz
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  args=($(echo "$@"))
+}
+
 function setup {
   install_md5deep
   mkdir -p $CASHER_DIR
@@ -235,8 +260,10 @@ function expand_path {
 }
 
 function main {
+  # $0 [opts] [cache|workspace] [globs]
+  process_flags "$@"
   setup
-  run "$@"
+  run "${args[@]}"
 }
 
 main "$@"

--- a/bin/casher
+++ b/bin/casher
@@ -45,8 +45,8 @@ function process_flags {
         PATHS_FILE=${CASHER_DIR}/${name}.paths
         CHECKSUM_FILE_BEFORE=${CASHER_DIR}/${name}.md5sums_before
         CHECKSUM_FILE_AFTER=${CASHER_DIR}/${name}.md5sums_after
-        FETCH_TAR=${CASHER_DIR}/${name}.tgz
-        PUSH_TAR=${CASHER_DIR}/${name}.tgz
+        FETCH_TAR=${CASHER_DIR}/${name}-fetch.tgz
+        PUSH_TAR=${CASHER_DIR}/${name}-push.tgz
         ;;
       *)
         break


### PR DESCRIPTION
Allow `--name` flag to pass the name of the cache/workspace/X to specify files, so that we can run `casher` separate entities without sharing a single file for data persistence.