### PR TITLE
Fix printf format

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -89,7 +89,7 @@ function msg {
       ;;
   esac
 
-  printf "${marker}%s${ANSI_RESET}\n" "$text"
+  printf "${marker}%b${ANSI_RESET}\n" "$text"
 }
 
 function run {


### PR DESCRIPTION
"%b" allows the argument to include escaped sequences such as "\n"