### PR TITLE
 Fix newlines in msg "changes detected..."

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -243,7 +243,7 @@ function changed_p {
   if [[ -s ${DIFF_FILE} ]]; then # DIFF_FILE has nonzero file size
     msg "changes detected (content changed, file is created, or file is deleted):" green
     change_msg=$(head -c ${MD5DEEP_CHECK_LOG_LIMIT} ${DIFF_FILE})$'\n'
-    diff_file_size=$(wc -c ${DIFF_FILE} | awk '{print $1}')
+    diff_file_size=$(wc -c < ${DIFF_FILE})
     if [[ ${diff_file_size} -gt ${MD5DEEP_CHECK_LOG_LIMIT} ]]; then
       change_msg="${change_msg}..."
     fi

--- a/bin/casher
+++ b/bin/casher
@@ -241,12 +241,13 @@ function changed_p {
     awk '/^[<>]/ {for (i=3; i<=NF; i++) printf("%s%s", $(i), i<NF? OFS : "\n")};' | sort | uniq > ${DIFF_FILE}
 
   if [[ -s ${DIFF_FILE} ]]; then # DIFF_FILE has nonzero file size
-    change_msg="changes detected (content changed, file is created, or file is deleted):\n$(head -c ${MD5DEEP_CHECK_LOG_LIMIT} ${DIFF_FILE})\n"
+    msg "changes detected (content changed, file is created, or file is deleted):" green
+    change_msg=$(head -c ${MD5DEEP_CHECK_LOG_LIMIT} ${DIFF_FILE})$'\n'
     diff_file_size=$(wc -c ${DIFF_FILE} | awk '{print $1}')
     if [[ ${diff_file_size} -gt ${MD5DEEP_CHECK_LOG_LIMIT} ]]; then
       change_msg="${change_msg}..."
     fi
-    msg "${change_msg}" green
+    msg "${change_msg}"
     CHANGED_P=TRUE
   fi
 }


### PR DESCRIPTION
There are currently two literal `\n` (backslash+n, not newlines) in the "changes detected" message: one on the first line, followed immediately by a changed file's name; another on the last line, after the last changed file name.

See for example: https://travis-ci.org/mapnik/mapnik/jobs/617797520#L2189-L2211

This PR changes the output such that the initial "changes detected..." line is printed separately, in green as before, and then the head of DIFF_FILE without coloring (I don't think it was actually intended to dump the whole thing in green; as you can see in the example above, color didn't persist across multiple lines).

This PR kinda voids #49 (which I think is a bad idea) and consequently #50.

Admittedly, #49 would fix this issue in its way, but at the same time create another: it would make the function `msg` clunky for printing anything coming from the outside (such as a list of user-created files). And #50 clearly shows that'd lead to leaning toothpick syndrome.
