### PR TITLE
Use /usr/bin/env for shebang.

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURL_FORMAT=<<-EOF
    time_namelookup:  %%{time_namelookup} s


### PR DESCRIPTION
Use `#!/usr/bin/env bash` for shebang, rather than `#!/bin/bash`. The
latter [isn't portable](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang), as at least *BSD put `bash` in `/usr/bin`.

This is currently stopping caching from working on FreeBSD builds, which
Travis now supports. ([Example 1](https://github.com/intel/media-driver/pull/819#issuecomment-632981526), [Example 2](https://github.com/RPCS3/rpcs3/pull/8261#issuecomment-630569214)).

I have verified that changing the shebang allows the script to run on a FreeBSD VM. I don't understand enough about what the script is doing to know how to test it thoroughly.