### PR TITLE
Update install_md5deep for FreeBSD

### DIFF
--- a/bin/casher
+++ b/bin/casher
@@ -222,6 +222,9 @@ function install_md5deep {
       msys_nt* | mingw*)
         chocolatey install hashdeep
         ;;
+      freebsd)
+        sudo pkg install -y md5deep
+        ;;
     esac
   fi
 }


### PR DESCRIPTION
This is to complement #54 to get casher to work on FreeBSD. With this PR and #54 it seems to be working.